### PR TITLE
[central] Change to central publishing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -365,6 +365,12 @@
           <artifactId>versions-maven-plugin</artifactId>
           <version>2.16.2</version>
         </plugin>
+        <plugin>
+          <groupId>org.sonatype.central</groupId>
+          <artifactId>central-publishing-maven-plugin</artifactId>
+          <version>0.7.0</version>
+          <extensions>true</extensions>
+      </plugin>
       </plugins>
     </pluginManagement>
 
@@ -497,6 +503,14 @@
           <useReleaseProfile>false</useReleaseProfile>
           <releaseProfiles>release</releaseProfiles>
           <goals>deploy</goals>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.sonatype.central</groupId>
+        <artifactId>central-publishing-maven-plugin</artifactId>
+        <extensions>true</extensions>
+        <configuration>
+          <publishingServerId>central</publishingServerId>
         </configuration>
       </plugin>
     </plugins>
@@ -840,13 +854,9 @@
 
   <distributionManagement>
     <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
     <site>
       <id>github</id>
       <url>scm:git:git@github.com:weblegacy/taglib-maven-plugin</url>


### PR DESCRIPTION
See https://central.sonatype.org/news/20250326_ossrh_sunset/ for all the details.

This is enough in the build files to be in working order.  Your local settings.xml will need to get a new token from central and over here https://central.sonatype.com/publishing/namespaces you will need to switch over via the migration.  The migration is a bit finicky but try a couple times and it generally will work.  If you plan to allow snapshots, you will need to enable that after the migration by checking options on the migrated namespace.  June is fast approaching so this is a good time to get ahead of this.  I've moved a lot of repos over at this point over last month or so.  The process is pretty solid in general.  When simply deploying a snapshot, deploy plugin is still used this way.  If releasing, the deploy plugin is overtaken and replaced with the central publishing plugin.  That does have some impact to other plugins like maven artifact plugin or cyclonedx-maven-plugin.  Basically any plugin that was relying on deploy would be affected.  In your build I don't see anything of impact otherwise.